### PR TITLE
Update README.md with SDL2 brew for OSX

### DIFF
--- a/README.md
+++ b/README.md
@@ -96,7 +96,7 @@ Complete Raspberry Pi build instructions at [emulationstation.org](http://emulat
 [XCode Dev Tools] (http://osxdaily.com/2014/02/12/install-command-line-tools-mac-os-x/)
 
 ```bash
-brew install cmake freeimage freetype eigen boost
+brew install cmake freeimage freetype eigen boost sdl2
 
 ```
 


### PR DESCRIPTION
I was getting a missing dependency error for sdl2 when compiling. So I added it to the OSX brew install list as it already was in the Linux and Windows sections.
