### PR TITLE
Wrap the checks for _MSC_VER value inside a check for the existence o…

### DIFF
--- a/es-core/src/Util.cpp
+++ b/es-core/src/Util.cpp
@@ -31,7 +31,7 @@ std::string strToUpper(const std::string& str)
 	return strToUpper(str.c_str());
 }
 
-
+#ifdef _MSC_VER
 #if _MSC_VER < 1800
 float round(float num)
 {
@@ -45,6 +45,7 @@ FILE * __iob_func(void)
 {
 	return iob;
 }
+#endif
 #endif
 
 Eigen::Affine3f& roundMatrix(Eigen::Affine3f& mat)

--- a/es-core/src/Util.h
+++ b/es-core/src/Util.h
@@ -15,9 +15,11 @@ Eigen::Affine3f roundMatrix(const Eigen::Affine3f& mat);
 Eigen::Vector3f roundVector(const Eigen::Vector3f& vec);
 Eigen::Vector2f roundVector(const Eigen::Vector2f& vec);
 
+#ifdef _MSC_VER
 #if _MSC_VER < 1800
 float round(float num);
 #endif /* _MSC_VER */
+#endif
 
 std::string getMd5(const boost::filesystem::path& path);
 std::string getCrc(const boost::filesystem::path& path);


### PR DESCRIPTION
…f the macro.

The GCC document says "Identifiers that are not macros, which are all considered to be the number zero." which I guess explains why building with GCC, 6 in my case, we enter these blocks that are only for MS VS.

It may not be the best way to do so, and I did not test if against MSC , but at least that's an idea :).
