### PR TITLE
PSP Scraper

### DIFF
--- a/es-app/src/scrapers/GamesDBScraper.cpp
+++ b/es-app/src/scrapers/GamesDBScraper.cpp
@@ -58,7 +58,7 @@ const std::map<PlatformId, const char*> gamesdb_platformid_map = boost::assign::
 	(PLAYSTATION_3, "Sony Playstation 3")
 	(PLAYSTATION_4, "Sony Playstation 4")
 	(PLAYSTATION_VITA, "Sony Playstation Vita")
-	(PLAYSTATION_PORTABLE, "Sony PSP")
+	(PLAYSTATION_PORTABLE, "Sony Playstation Portable")
 	(SUPER_NINTENDO, "Super Nintendo (SNES)")
 	(TURBOGRAFX_16, "TurboGrafx 16")
 	(WONDERSWAN, "WonderSwan")


### PR DESCRIPTION
The PSP scraper did not work, updated with "Sony Playstation Portable".
This is probably due to a change in the PSP pages of thegamesdb.net where you can see:
`<a style="color: #fff;" href="http://thegamesdb.net/platform/sony-psp/">Sony Playstation Portable</a>`